### PR TITLE
Add option to skip certain selectors from being prefixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 **Options:**
 
 ```js
-{selector: '.parent'}
+{selector: '.parent', ignoredSelectors: ['.do-not-prefix-me']}
 ```
 
 **Input CSS:**
@@ -54,7 +54,7 @@ The `selector` option takes a string value that should be placed at the beginnin
 {selector: 'div.parent-class'}
 ```
 
-The `ignoredSelector` option takes an array value that contains all selectors that should not be prefixed by given `selector` (see above).
+The `ignoredSelectors` option takes an array value that contains all selectors that should not be prefixed by given `selector` (see above).
 ```js
 // element
 {ignoredSelectors: ['.do-not-prefix-me']}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ The `selector` option takes a string value that should be placed at the beginnin
 {selector: 'div.parent-class'}
 ```
 
-
+The `ignoredSelector` option takes an array value that contains all selectors that should not be prefixed by given `selector` (see above).
+```js
+// element
+{ignoredSelectors: ['.do-not-prefix-me']}
+```
 
 ## Usage
 ```js

--- a/index.js
+++ b/index.js
@@ -1,13 +1,28 @@
 var postcss = require('postcss');
 
+function isNonRelevantRule(rule) {
+    return rule.parent && rule.parent.type === 'atrule' &&
+        rule.parent.name.indexOf('keyframes') !== -1;
+}
+
+function hasIgnoredSelectors(selectors, ignoredSelectors) {
+    return selectors.some(selector =>
+        ignoredSelectors.find(ignored => ignored === selector));
+}
+
+function isIgnoredRule(rule, ignoredSelectors) {
+    return ignoredSelectors && ignoredSelectors.length &&
+        hasIgnoredSelectors(rule.selectors, ignoredSelectors);
+}
+
 module.exports = postcss.plugin('postcss-parent-selector', function (opts) {
     opts = opts || {};
 
     // Work with options here
     return function (root /* , result*/ ) {
         root.walkRules(rule => {
-            if (rule.parent && rule.parent.type === 'atrule' &&
-                rule.parent.name.indexOf('keyframes') !== -1) {
+            if (isNonRelevantRule(rule) ||
+                isIgnoredRule(rule, opts.ignoredSelectors)) {
                 return;
             }
             rule.selectors = rule.selectors.map(selectors => {

--- a/test.js
+++ b/test.js
@@ -35,3 +35,19 @@ test('does not add parent class to keyframes names', t => {
         { selector: '.parent' });
 });
 
+
+test('does not add parent class to an ignored selector', t => {
+    return run(
+        t,
+        '* { }',
+        '* { }',
+        { selector: '.parent', ignoredSelectors:['*'] });
+});
+
+test('selector is added to rule if ignoredSelector is not strict equal', t => {
+    return run(
+        t,
+        '.foo * { }',
+        '.parent .foo * { }',
+        { selector: '.parent', ignoredSelectors:['*'] });
+});


### PR DESCRIPTION
Hey,

We've added an option to skip certain selectors from being prefixed. Maybe someone else can use it.
This is very useful if you are working with a CSS Reset Library (e.g. https://github.com/filipelinhares/ress) and don't want to add unnecessarily high specificity to certain general selectors like '*' or ':after' etc.

Regards,
Julian