### PR TITLE
Adding exceptions and appedTo methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,40 @@ The `selector` option takes a string value that should be placed at the beginnin
 {selector: 'div.parent-class'}
 ```
 
+The `exceptions` option takes an array of string values that should be ignored. This can serve useful if you have a `body` or `html` selector in your css file.
+
+```js
+// input
+{selector: '.parent', excetions: ['body', 'html']}
+```
+
+```css
+.parent .foo {
+    /* Output example */
+}
+
+body {
+    /* Output example */
+}
+```
+
+The `appendTo` option takes an array of string values on which you want the new selector to applied.
+
+```js
+// input
+{selector: '.parent', appendTo: ['body']}
+```
+
+```css
+.parent .foo {
+    /* Output example */
+}
+
+body.parent {
+    /* Output example */
+}
+```
+
 
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -22,11 +22,6 @@ module.exports = postcss.plugin('postcss-parent-selector', function (opts) {
                     if (Array.isArray(opts.appendTo) && opts.appendTo.includes(selector)) {
                         return `${selector}${opts.selector}`;
                     }
-                    
-                    // Certain rules for prepending a selector to another 
-                    if (Array.isArray(opts.prependTo) && opts.prependTo.includes(selector)) {
-                        return `${opts.selector}${selector}`;
-                    }
 
                     // Return new selector
                     return `${opts.selector} ${selector}`;

--- a/index.js
+++ b/index.js
@@ -14,11 +14,22 @@ module.exports = postcss.plugin('postcss-parent-selector', function (opts) {
                 return selectors.split(/,[\s]* /g).map( selector => {
                     // don't add the parent class to a rule that is
                     // exactly equal to the one defined by the user
-                    if ( selector === opts.selector ) {
+                    if (selector === opts.selector || (Array.isArray(opts.exceptions) && opts.exceptions.includes(selector))) {
                         return selector;
                     }
-                    var newsSelector = `${opts.selector} ${selector}`;
-                    return newsSelector;
+                    
+                    // Certain rules for appending a selector to another 
+                    if (Array.isArray(opts.appendTo) && opts.appendTo.includes(selector)) {
+                        return `${selector}${opts.selector}`;
+                    }
+                    
+                    // Certain rules for prepending a selector to another 
+                    if (Array.isArray(opts.prependTo) && opts.prependTo.includes(selector)) {
+                        return `${opts.selector}${selector}`;
+                    }
+
+                    // Return new selector
+                    return `${opts.selector} ${selector}`;
                 });
             });
         });


### PR DESCRIPTION
I was using this to add a parent class to a compiled stylesheet, which included a `body` and `html` element. As I didn't want the paren't class added to these, I added the exceptions array. I then wanted a different version, two different colours, so I found it useful to add the parent class to the body element, why I believe this is also a useful method.